### PR TITLE
Enable IPv6 in osl-keepalived::haproxy-phpbb

### DIFF
--- a/recipes/haproxy_phpbb.rb
+++ b/recipes/haproxy_phpbb.rb
@@ -48,14 +48,12 @@ keepalived_vrrp_instance 'haproxy-phpbb-ipv6' do
   # Authentication isn't actually used with IPv6 (see https://tools.ietf.org/html/rfc5798#section-9)
   # however, keepalived cookbook requires this to be defined
   authentication auth_type: 'PASS', auth_pass: secrets['auth_pass']
-  virtual_ipaddress %w() # TODO: IPv6 for lb.phpbb.com
+  virtual_ipaddress %w(2605:bc80:3010:103::8cd3:ff4/64)
   notifies :reload, 'service[keepalived]'
-  action :nothing # TODO: IPv6 for lb.phpbb.com
 end
 
 # Sync group ensures IPv4 and IPv6 fail over together
 keepalived_vrrp_sync_group 'haproxy-phpbb-group' do
   group %w(haproxy-phpbb-ipv4 haproxy-phpbb-ipv6)
   notifies :reload, 'service[keepalived]'
-  action :nothing # TODO: IPv6 for lb.phpbb.com
 end

--- a/spec/unit/recipes/haproxy_phpbb_spec.rb
+++ b/spec/unit/recipes/haproxy_phpbb_spec.rb
@@ -24,10 +24,10 @@ describe 'osl-keepalived::haproxy_phpbb' do
         it do
           expect(chef_run.keepalived_vrrp_instance("haproxy-phpbb-#{ip}")).to notify('service[keepalived]').to(:reload)
         end
-        it do
-          expect(chef_run.keepalived_vrrp_sync_group('haproxy-phpbb-group')).to \
-            notify('service[keepalived]').to(:reload)
-        end
+      end
+      it do
+        expect(chef_run.keepalived_vrrp_sync_group('haproxy-phpbb-group')).to \
+          notify('service[keepalived]').to(:reload)
       end
     end
 

--- a/test/integration/haproxy_phpbb/serverspec/haproxy_phpbb_spec.rb
+++ b/test/integration/haproxy_phpbb/serverspec/haproxy_phpbb_spec.rb
@@ -30,13 +30,39 @@ describe file '/etc/keepalived/conf.d/keepalived_vrrp_instance__haproxy-phpbb-ip
 end
 
 describe file '/etc/keepalived/conf.d/keepalived_vrrp_instance__haproxy-phpbb-ipv6__.conf' do
-  it { should_not exist }
+  its(:content) do
+    should match(
+      %r{vrrp_instance haproxy-phpbb-ipv6 {
+	state MASTER
+	virtual_router_id 4
+	interface eth0
+	priority 200
+	authentication {
+		auth_type PASS
+		auth_pass foobar
+		}
+	virtual_ipaddress {
+		2605:bc80:3010:103::8cd3:ff4/64
+		}
+	}}
+    )
+  end
 end
 
 describe file '/etc/keepalived/conf.d/keepalived_vrrp_sync_group__haproxy-phpbb-group__.conf' do
-  it { should_not exist }
+  its(:content) do
+    should match(
+      /vrrp_sync_group haproxy-phpbb-group {
+	group {
+		haproxy-phpbb-ipv4
+		haproxy-phpbb-ipv6
+		}
+	}/
+    )
+  end
 end
 
 describe interface 'eth0' do
   it { should have_ipv4_address '140.211.15.244/24' }
+  it { should have_ipv6_address '2605:bc80:3010:103::8cd3:ff4/64' }
 end


### PR DESCRIPTION
Now that keepalived has been deployed for phpBB's load balancer (`lb.phpbb.com`), we can enable variable IPs for both IPv4 and IPv6.

This will not be deployed until after https://git.osuosl.org/osuosl-chef/data_bags/merge_requests/421