### PR TITLE
Use correct TLD for phpbb nodes

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,7 +34,7 @@ suites:
          haproxy:
             interface: 'eth1'
       keepalived_test:
-        fqdn: lb1.phpbb.org
+        fqdn: lb1.phpbb.com
   - name: mysql2
     run_list:
       - recipe[keepalived_test::mysql_test]

--- a/recipes/haproxy_phpbb.rb
+++ b/recipes/haproxy_phpbb.rb
@@ -17,13 +17,13 @@
 # limitations under the License.
 #
 node.default['osl-keepalived']['master'] = {
-  'lb1.phpbb.org' => true,
-  'lb2.phpbb.org' => false,
+  'lb1.phpbb.com' => true,
+  'lb2.phpbb.com' => false,
 }
 
 node.default['osl-keepalived']['priority'] = {
-  'lb1.phpbb.org' => 200,
-  'lb2.phpbb.org' => 100,
+  'lb1.phpbb.com' => 200,
+  'lb2.phpbb.com' => 100,
 }
 
 include_recipe 'osl-keepalived::default'

--- a/spec/unit/recipes/haproxy_phpbb_spec.rb
+++ b/spec/unit/recipes/haproxy_phpbb_spec.rb
@@ -31,10 +31,10 @@ describe 'osl-keepalived::haproxy_phpbb' do
       end
     end
 
-    context "#{p[:platform]} #{p[:version]} for lb1.phpbb.org" do
+    context "#{p[:platform]} #{p[:version]} for lb1.phpbb.com" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p) do |node|
-          node.automatic_attrs['fqdn'] = 'lb1.phpbb.org'
+          node.automatic_attrs['fqdn'] = 'lb1.phpbb.com'
         end.converge(described_recipe)
       end
       it do
@@ -58,10 +58,10 @@ describe 'osl-keepalived::haproxy_phpbb' do
         )
       end
     end
-    context "#{p[:platform]} #{p[:version]} for lb2.phpbb.org" do
+    context "#{p[:platform]} #{p[:version]} for lb2.phpbb.com" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p) do |node|
-          node.automatic_attrs['fqdn'] = 'lb2.phpbb.org'
+          node.automatic_attrs['fqdn'] = 'lb2.phpbb.com'
         end.converge(described_recipe)
       end
       it do


### PR DESCRIPTION
The phpbb nodes use phpbb.com NOT phpbb.org. This is causing issues where lb1 doesn't act as the primary.
