### PR TITLE
Changes to terminology, mainly remove the term 'master'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is OSL's wrapper cookbook for utilizing the [keepalived cookbook](https://s
 
 | Key                                    | Description                     |
 |----------------------------------------|---------------------------------|
-| `['osl-keepalived']['default_master']` | FQDN of the default master node |
+| `['osl-keepalived']['primary']` | FQDN of the default master node |
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
-default['osl-keepalived']['master'] = nil
+default['osl-keepalived']['primary'] = nil
 default['osl-keepalived']['priority'] = nil

--- a/recipes/haproxy_osuosl.rb
+++ b/recipes/haproxy_osuosl.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node.default['osl-keepalived']['master'] = {
+node.default['osl-keepalived']['primary'] = {
   'lb1.osuosl.org' => true,
   'lb2.osuosl.org' => false,
 }
@@ -31,7 +31,7 @@ include_recipe 'osl-keepalived::default'
 secrets = data_bag_item('osl_keepalived', 'haproxy_osuosl')
 
 keepalived_vrrp_instance 'haproxy-osuosl-ipv4' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface node['osl-keepalived']['haproxy']['interface']
   virtual_router_id 1
   priority node['osl-keepalived']['priority'][node['fqdn']]
@@ -41,7 +41,7 @@ keepalived_vrrp_instance 'haproxy-osuosl-ipv4' do
 end
 
 keepalived_vrrp_instance 'haproxy-osuosl-ipv6' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface node['osl-keepalived']['haproxy']['interface']
   virtual_router_id 2
   priority node['osl-keepalived']['priority'][node['fqdn']]

--- a/recipes/haproxy_phpbb.rb
+++ b/recipes/haproxy_phpbb.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-node.default['osl-keepalived']['master'] = {
+node.default['osl-keepalived']['primary'] = {
   'lb1.phpbb.com' => true,
   'lb2.phpbb.com' => false,
 }
@@ -31,7 +31,7 @@ include_recipe 'osl-keepalived::default'
 secrets = data_bag_item('osl_keepalived', 'haproxy_phpbb')
 
 keepalived_vrrp_instance 'haproxy-phpbb-ipv4' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface node['osl-keepalived']['haproxy']['interface']
   virtual_router_id 3
   priority node['osl-keepalived']['priority'][node['fqdn']]
@@ -41,7 +41,7 @@ keepalived_vrrp_instance 'haproxy-phpbb-ipv4' do
 end
 
 keepalived_vrrp_instance 'haproxy-phpbb-ipv6' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface node['osl-keepalived']['haproxy']['interface']
   virtual_router_id 4
   priority node['osl-keepalived']['priority'][node['fqdn']]

--- a/recipes/mysql2.rb
+++ b/recipes/mysql2.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node.default['osl-keepalived']['master'] = {
+node.default['osl-keepalived']['primary'] = {
   'mysql3.osuosl.org' => true,
   'mysql4.osuosl.org' => false,
 }
@@ -31,7 +31,7 @@ include_recipe 'osl-keepalived::default'
 secrets = data_bag_item('osl_keepalived', 'mysql')
 
 keepalived_vrrp_instance 'mysql-ipv4' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface node['osl-keepalived']['haproxy']['interface']
   virtual_router_id 5
   priority node['osl-keepalived']['priority'][node['fqdn']]
@@ -41,7 +41,7 @@ keepalived_vrrp_instance 'mysql-ipv4' do
 end
 
 keepalived_vrrp_instance 'mysql-backend-ipv4' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface 'eth1'
   virtual_router_id 6
   priority node['osl-keepalived']['priority'][node['fqdn']]

--- a/test/cookbooks/keepalived_test/recipes/provisioning.rb
+++ b/test/cookbooks/keepalived_test/recipes/provisioning.rb
@@ -1,6 +1,6 @@
 osl_firewall_port 'http'
 
-node.default['osl-keepalived']['master'] = {
+node.default['osl-keepalived']['primary'] = {
   'node1.novalocal' => true,
   'node2.novalocal' => false,
 }
@@ -29,7 +29,7 @@ osl_ifconfig "192.168.60.#{node['keepalived_test']['ip']}" do
 end
 
 keepalived_vrrp_instance 'default_ipv4' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface 'eth1'
   virtual_router_id 1
   priority node['osl-keepalived']['priority'][node['fqdn']]
@@ -39,7 +39,7 @@ keepalived_vrrp_instance 'default_ipv4' do
 end
 
 keepalived_vrrp_instance 'default_ipv6' do
-  master node['osl-keepalived']['master'][node['fqdn']]
+  master node['osl-keepalived']['primary'][node['fqdn']]
   interface 'eth1'
   virtual_router_id 2
   priority node['osl-keepalived']['priority'][node['fqdn']]


### PR DESCRIPTION
Removed the term 'master' from an attribute in the default attributes file, and subsequent files that used it.