### PR TITLE
Bump keepalived to Chef 17-compliant version

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,12 +1,9 @@
 source 'https://supermarket.chef.io'
 
 cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
-cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
 cookbook 'osl-repos', git: 'git@github.com:osuosl-cookbooks/osl-repos'
-
-# TODO: Remove this after we update to a newer ark
-cookbook 'seven_zip', '< 4.0.0'
+cookbook 'osl-selinux', git: 'git@github.com:osuosl-cookbooks/osl-selinux'
 
 cookbook 'keepalived_test', path: 'test/cookbooks/keepalived_test'
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -59,8 +59,7 @@ suites:
       name: terraform
       command_timeout: 1800
     excludes:
-      - centos-8
-      - centos-stream-8
+      - centos_stream-8
     provisioner: terraform
     verifier:
       name: terraform
@@ -89,10 +88,9 @@ suites:
       name: terraform
       command_timeout: 1800
       variables:
-        centos_image: "CentOS 8.2"
+        centos_image: "CentOS Stream 8"
     excludes:
       - centos-7
-      - centos-stream-8
     provisioner: terraform
     verifier:
       name: terraform

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,6 +13,7 @@ suites:
   - name: default
     run_list:
       - recipe[osl-keepalived::default]
+
   - name: haproxy_osuosl
     run_list:
       - recipe[keepalived_test::haproxy_test]
@@ -24,6 +25,7 @@ suites:
             interface: 'eth1'
       keepalived_test:
         fqdn: lb1.osuosl.org
+
   - name: haproxy_phpbb
     run_list:
       - recipe[keepalived_test::haproxy_test]
@@ -35,6 +37,7 @@ suites:
             interface: 'eth1'
       keepalived_test:
         fqdn: lb1.phpbb.com
+
   - name: mysql2
     run_list:
       - recipe[keepalived_test::mysql_test]
@@ -50,61 +53,65 @@ suites:
           ipv4: 140.211.9.50/24
         eth2:
           ipv4: 140.211.9.50/24
-#  - name: multi-node-7
-#    driver:
-#      name: terraform
-#      command_timeout: 1800
-#    excludes:
-#      - centos-8
-#    provisioner: terraform
-#    verifier:
-#      name: terraform
-#      systems:
-#        - name: node1
-#          backend: ssh
-#          hosts_output: node1
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - node1
-#          hostnames: node1
-#        - name: node2
-#          backend: ssh
-#          hosts_output: node2
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - node2
-#          hostnames: node2
-#  - name: multi-node-8
-#    driver:
-#      name: terraform
-#      command_timeout: 1800
-#      variables:
-#        centos_image: "CentOS 8.2"
-#    excludes:
-#      - centos-7
-#    provisioner: terraform
-#    verifier:
-#      name: terraform
-#      systems:
-#        - name: node1
-#          backend: ssh
-#          hosts_output: node1
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - node1
-#          hostnames: node1
-#        - name: node2
-#          backend: ssh
-#          hosts_output: node2
-#          sudo: true
-#          user: centos
-#          controls:
-#            - all
-#            - node2
-#          hostnames: node2
+
+  - name: multi-node-7
+    driver:
+      name: terraform
+      command_timeout: 1800
+    excludes:
+      - centos-8
+      - centos-stream-8
+    provisioner: terraform
+    verifier:
+      name: terraform
+      systems:
+        - name: node1
+          backend: ssh
+          hosts_output: node1
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - node1
+          hostnames: node1
+        - name: node2
+          backend: ssh
+          hosts_output: node2
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - node2
+          hostnames: node2
+
+  - name: multi-node-8
+    driver:
+      name: terraform
+      command_timeout: 1800
+      variables:
+        centos_image: "CentOS 8.2"
+    excludes:
+      - centos-7
+      - centos-stream-8
+    provisioner: terraform
+    verifier:
+      name: terraform
+      systems:
+        - name: node1
+          backend: ssh
+          hosts_output: node1
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - node1
+          hostnames: node1
+        - name: node2
+          backend: ssh
+          hosts_output: node2
+          sudo: true
+          user: centos
+          controls:
+            - all
+            - node2
+          hostnames: node2

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "openstack" {
+    version = "~> 1.43.0"
+}
+
 resource "openstack_networking_network_v2" "keepalived_openstack_network" {
     name            = "keepalived_openstack_network"
     admin_state_up  = "true"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ description      'Installs/Configures osl-keepalived'
 version          '2.1.0'
 
 depends          'osl-firewall'
-depends          'keepalived', '~> 5.1.0'
+depends          'keepalived', '~> 6.0.0'
 
 supports         'centos', '~> 7.0'
 supports         'centos', '~> 8.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,5 +12,4 @@ depends          'osl-firewall'
 depends          'keepalived', '~> 6.0.0'
 
 supports         'centos', '~> 7.0'
-supports         'centos', '~> 8.0'
 supports         'centos_stream', '~> 8.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: default
 #
-# Copyright:: 2018-2021, Oregon State University
+# Copyright:: 2018-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/haproxy_osuosl.rb
+++ b/recipes/haproxy_osuosl.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: haproxy-osuosl
 #
-# Copyright:: 2018-2021, Oregon State University
+# Copyright:: 2018-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/haproxy_phpbb.rb
+++ b/recipes/haproxy_phpbb.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: haproxy_phpbb
 #
-# Copyright:: 2018-2021, Oregon State University
+# Copyright:: 2018-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/mysql2.rb
+++ b/recipes/mysql2.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: mysql
 #
-# Copyright:: 2018-2021, Oregon State University
+# Copyright:: 2018-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/keepalived_test/recipes/fake_int.rb
+++ b/test/cookbooks/keepalived_test/recipes/fake_int.rb
@@ -2,7 +2,7 @@
 # Cookbook:: keepalived_test
 # Recipe:: eth1
 #
-# Copyright:: 2018-2021, Oregon State University
+# Copyright:: 2018-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/keepalived_test/recipes/hostname.rb
+++ b/test/cookbooks/keepalived_test/recipes/hostname.rb
@@ -2,7 +2,7 @@
 # Cookbook:: keepalived_test
 # Recipe:: hostname
 #
-# Copyright:: 2018-2021, Oregon State University
+# Copyright:: 2018-2022, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also re-enables multi-node tests with a pinned Openstack provider.