### PR TITLE
Make mysql vip stay on whatever host it's currently on

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['osl-keepalived']['primary'] = nil
 default['osl-keepalived']['priority'] = nil
+default['osl-keepalived']['default_interface'] = node['network']['default_interface']

--- a/attributes/haproxy.rb
+++ b/attributes/haproxy.rb
@@ -1,1 +1,0 @@
-default['osl-keepalived']['haproxy']['interface'] = node['network']['default_interface']

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,8 +34,7 @@ suites:
       - recipe[osl-keepalived::haproxy_osuosl]
     attributes:
       osl-keepalived:
-         haproxy:
-            interface: 'eth1'
+         default_interface: 'eth1'
       keepalived_test:
         fqdn: lb1.osuosl.org
 
@@ -46,8 +45,7 @@ suites:
       - recipe[osl-keepalived::haproxy_phpbb]
     attributes:
       osl-keepalived:
-         haproxy:
-            interface: 'eth1'
+         default_interface: 'eth1'
       keepalived_test:
         fqdn: lb1.phpbb.com
 
@@ -58,8 +56,7 @@ suites:
       - recipe[osl-keepalived::mysql1]
     attributes:
       osl-keepalived:
-         haproxy:
-            interface: 'eth1'
+         default_interface: 'eth1'
       keepalived_test:
         fqdn: mysql1.osuosl.org
         eth1:
@@ -72,8 +69,7 @@ suites:
       - recipe[osl-keepalived::mysql2]
     attributes:
       osl-keepalived:
-         haproxy:
-            interface: 'eno1'
+         default_interface: 'eno1'
       keepalived_test:
         fqdn: mysql3.osuosl.org
         eno1:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: default
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/haproxy_osuosl.rb
+++ b/recipes/haproxy_osuosl.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: haproxy-osuosl
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ secrets = data_bag_item('osl_keepalived', 'haproxy_osuosl')
 
 keepalived_vrrp_instance 'haproxy-osuosl-ipv4' do
   master node['osl-keepalived']['primary'][node['fqdn']]
-  interface node['osl-keepalived']['haproxy']['interface']
+  interface node['osl-keepalived']['default_interface']
   virtual_router_id 1
   priority node['osl-keepalived']['priority'][node['fqdn']]
   authentication auth_type: 'PASS', auth_pass: secrets['auth_pass']
@@ -42,7 +42,7 @@ end
 
 keepalived_vrrp_instance 'haproxy-osuosl-ipv6' do
   master node['osl-keepalived']['primary'][node['fqdn']]
-  interface node['osl-keepalived']['haproxy']['interface']
+  interface node['osl-keepalived']['default_interface']
   virtual_router_id 2
   priority node['osl-keepalived']['priority'][node['fqdn']]
   # Authentication isn't actually used with IPv6 (see https://tools.ietf.org/html/rfc5798#section-9)

--- a/recipes/haproxy_phpbb.rb
+++ b/recipes/haproxy_phpbb.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: haproxy_phpbb
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ secrets = data_bag_item('osl_keepalived', 'haproxy_phpbb')
 
 keepalived_vrrp_instance 'haproxy-phpbb-ipv4' do
   master node['osl-keepalived']['primary'][node['fqdn']]
-  interface node['osl-keepalived']['haproxy']['interface']
+  interface node['osl-keepalived']['default_interface']
   virtual_router_id 3
   priority node['osl-keepalived']['priority'][node['fqdn']]
   authentication auth_type: 'PASS', auth_pass: secrets['auth_pass']
@@ -42,7 +42,7 @@ end
 
 keepalived_vrrp_instance 'haproxy-phpbb-ipv6' do
   master node['osl-keepalived']['primary'][node['fqdn']]
-  interface node['osl-keepalived']['haproxy']['interface']
+  interface node['osl-keepalived']['default_interface']
   virtual_router_id 4
   priority node['osl-keepalived']['priority'][node['fqdn']]
   # Authentication isn't actually used with IPv6 (see https://tools.ietf.org/html/rfc5798#section-9)

--- a/recipes/mysql1.rb
+++ b/recipes/mysql1.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: mysql
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ secrets = data_bag_item('osl_keepalived', 'mysql_vip1')
 
 keepalived_vrrp_instance 'mysql-ipv4' do
   master node['osl-keepalived']['primary'][node['fqdn']]
-  interface node['osl-keepalived']['haproxy']['interface']
+  interface node['osl-keepalived']['default_interface']
+  nopreempt !node['osl-keepalived']['primary'][node['fqdn']]
   virtual_router_id 7
   priority node['osl-keepalived']['priority'][node['fqdn']]
   authentication auth_type: 'PASS', auth_pass: secrets['auth_pass']

--- a/recipes/mysql2.rb
+++ b/recipes/mysql2.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-keepalived
 # Recipe:: mysql
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ secrets = data_bag_item('osl_keepalived', 'mysql_vip2')
 
 keepalived_vrrp_instance 'mysql-ipv4' do
   master node['osl-keepalived']['primary'][node['fqdn']]
-  interface node['osl-keepalived']['haproxy']['interface']
+  interface node['osl-keepalived']['default_interface']
+  nopreempt !node['osl-keepalived']['primary'][node['fqdn']]
   virtual_router_id 5
   priority node['osl-keepalived']['priority'][node['fqdn']]
   authentication auth_type: 'PASS', auth_pass: secrets['auth_pass']
@@ -43,6 +44,7 @@ end
 keepalived_vrrp_instance 'mysql-backend-ipv4' do
   master node['osl-keepalived']['primary'][node['fqdn']]
   interface 'eno2'
+  nopreempt !node['osl-keepalived']['primary'][node['fqdn']]
   virtual_router_id 6
   priority node['osl-keepalived']['priority'][node['fqdn']]
   authentication auth_type: 'PASS', auth_pass: secrets['auth_pass']

--- a/spec/unit/recipes/mysql1_spec.rb
+++ b/spec/unit/recipes/mysql1_spec.rb
@@ -30,6 +30,7 @@ describe 'osl-keepalived::mysql1' do
         expect(chef_run).to create_keepalived_vrrp_instance('mysql-ipv4').with(
           master: true,
           interface: 'eth0',
+          nopreempt: false,
           virtual_router_id: 7,
           priority: 200,
           authentication: { auth_type: 'PASS', auth_pass: 'foobar' },
@@ -47,6 +48,7 @@ describe 'osl-keepalived::mysql1' do
         expect(chef_run).to create_keepalived_vrrp_instance('mysql-ipv4').with(
           master: false,
           interface: 'eth0',
+          nopreempt: true,
           virtual_router_id: 7,
           priority: 100,
           authentication: { auth_type: 'PASS', auth_pass: 'foobar' },

--- a/spec/unit/recipes/mysql2_spec.rb
+++ b/spec/unit/recipes/mysql2_spec.rb
@@ -33,6 +33,7 @@ describe 'osl-keepalived::mysql2' do
         expect(chef_run).to create_keepalived_vrrp_instance('mysql-ipv4').with(
           master: true,
           interface: 'eth0',
+          nopreempt: false,
           virtual_router_id: 5,
           priority: 200,
           authentication: { auth_type: 'PASS', auth_pass: 'foobar' },
@@ -43,6 +44,7 @@ describe 'osl-keepalived::mysql2' do
         expect(chef_run).to create_keepalived_vrrp_instance('mysql-backend-ipv4').with(
           master: true,
           interface: 'eno2',
+          nopreempt: false,
           virtual_router_id: 6,
           priority: 200,
           authentication: { auth_type: 'PASS', auth_pass: 'foobar' },
@@ -60,6 +62,7 @@ describe 'osl-keepalived::mysql2' do
         expect(chef_run).to create_keepalived_vrrp_instance('mysql-ipv4').with(
           master: false,
           interface: 'eth0',
+          nopreempt: true,
           virtual_router_id: 5,
           priority: 100,
           authentication: { auth_type: 'PASS', auth_pass: 'foobar' },
@@ -70,6 +73,7 @@ describe 'osl-keepalived::mysql2' do
         expect(chef_run).to create_keepalived_vrrp_instance('mysql-backend-ipv4').with(
           master: false,
           interface: 'eno2',
+          nopreempt: true,
           virtual_router_id: 6,
           priority: 100,
           authentication: { auth_type: 'PASS', auth_pass: 'foobar' },

--- a/test/cookbooks/keepalived_test/recipes/fake_int.rb
+++ b/test/cookbooks/keepalived_test/recipes/fake_int.rb
@@ -2,7 +2,7 @@
 # Cookbook:: keepalived_test
 # Recipe:: eth1
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/cookbooks/keepalived_test/recipes/hostname.rb
+++ b/test/cookbooks/keepalived_test/recipes/hostname.rb
@@ -2,7 +2,7 @@
 # Cookbook:: keepalived_test
 # Recipe:: hostname
 #
-# Copyright:: 2018-2024, Oregon State University
+# Copyright:: 2018-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This should hopefully fix an issue we've had for a while when trying to reboot
the primary server before it's ready. Adding nopreempt to the backup/secondary
will ensure that it keeps the VIP until we manually move it over.

Other fixes:

- Rename default['osl-keepalived']['haproxy']['interface'] to
  default['osl-keepalived']['default_interface'] to better reflect what it's
  actually for

Signed-off-by: Lance Albertson <lance@osuosl.org>
